### PR TITLE
Rescue from `::StandardError`

### DIFF
--- a/lib/awis/models/url_info.rb
+++ b/lib/awis/models/url_info.rb
@@ -306,7 +306,7 @@ module Awis
 
       def float_value?(text)
         !!Float(text.delete('%'))
-      rescue StandardError
+      rescue ::StandardError
         false
       end
     end


### PR DESCRIPTION
`lib/awis/exceptions.rb` overrides ruby's `StandardError` with an AWIS specific `StandardError`, this prevents the `rescue` from catching `Float()`'s `ArgumentError`:


```
$ bundle exec rake test
/usr/local/var/rbenv/versions/2.6.1/bin/ruby -w -I"lib:lib:test" -I"/usr/local/var/rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib" "/usr/local/var/rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/rake-12.3.2/lib/rake/rake_test_loader.rb" "test/api/category_browse_test.rb" "test/api/category_listings_test.rb" "test/api/sites_linking_in_test.rb" "test/api/traffic_history_test.rb" "test/api/url_info_test.rb" "test/client_test.rb"
Run options: --seed 10584

# Running:

.............EEEEEEEEEEEEEEE.........EEEEE........

Finished in 0.550692s, 90.7949 runs/s, 56.2928 assertions/s.

  1) Error:
Awis::API::UrlInfo::with github.com rank response group#test_0001_Should be has request id:
ArgumentError: invalid value for Float(): "<aws:Response xmlns:aws=\"http://awis.amazonaws.com/doc/2005-07-11\"><aws:OperationRequest><aws:RequestId>2df424ef-f1fe-5452-c372-ea598784dbd7</aws:RequestId></aws:OperationRequest><aws:UrlInfoResult><aws:Alexa>\n  \n  <aws:TrafficData>\n    <aws:DataUrl type=\"canonical\">github.com/</aws:DataUrl>\n    <aws:Rank>69</aws:Rank>\n  </aws:TrafficData>\n</aws:Alexa></aws:UrlInfoResult><aws:ResponseStatus xmlns:aws=\"http://alexa.amazonaws.com/doc/2005-07-11/\"><aws:StatusCode>Success</aws:StatusCode></aws:ResponseStatus></aws:Response>"
    /Users/max/code/github/amazon-awis/lib/awis/models/url_info.rb:308:in `Float'
    /Users/max/code/github/amazon-awis/lib/awis/models/url_info.rb:308:in `float_value?'
    /Users/max/code/github/amazon-awis/lib/awis/models/url_info.rb:38:in `block in setup_data!'
    /Users/max/code/github/amazon-awis/lib/awis/utils/xml.rb:30:in `block in each_node'
    /usr/local/var/rbenv/versions/2.6.1/lib/ruby/gems/2.6.0/gems/nokogiri-1.10.1/lib/nokogiri/xml/reader.rb:107:in `each'
    /Users/max/code/github/amazon-awis/lib/awis/utils/xml.rb:16:in `each_node'
    /Users/max/code/github/amazon-awis/lib/awis/models/url_info.rb:33:in `setup_data!'
    /Users/max/code/github/amazon-awis/lib/awis/models/url_info.rb:16:in `initialize'
    /Users/max/code/github/amazon-awis/lib/awis/client.rb:34:in `new'
    /Users/max/code/github/amazon-awis/lib/awis/client.rb:34:in `parse_response_with_request'
    /Users/max/code/github/amazon-awis/lib/awis/client.rb:10:in `url_info'
    /Users/max/code/github/amazon-awis/test/api/url_info_test.rb:114:in `block (3 levels) in <top (required)>'
...
```